### PR TITLE
Switching to (S)CSS Modules

### DIFF
--- a/src/components/Layout/Footer/Footer.module.scss
+++ b/src/components/Layout/Footer/Footer.module.scss
@@ -1,12 +1,12 @@
 @import '../../../styles/variables';
 
-.scout-footer {
+.container {
     color: #fff;
     text-align: center;
     padding-top: 1.5rem;
     background-color: rgba($official-corporate-blue, 0.55);
 
-    .scout-footer-top {
+    .top {
         margin: 0;
 
         ul {
@@ -52,26 +52,28 @@
         }
     }
 
-    .scout-footer-bottom {
+    .bottom {
         background-color: $official-corporate-blue;
         padding: 0.75rem 0;
     }
 }
 
 html[data-theme='cub'] {
-    .scout-footer {
+    .container {
         background-color: rgba($official-cs-blue, 0.55);
-    }
-    .scout-footer-bottom {
-        background-color: $official-cs-blue;
+
+        .bottom {
+            background-color: $official-cs-blue;
+        }
     }
 }
 
 html[data-theme='bsa'] {
-    .scout-footer {
+    .container {
         background-color: rgba($official-bsa-olive, 0.55);
-    }
-    .scout-footer-bottom {
-        background-color: $official-bsa-olive;
+
+        .bottom {
+            background-color: $official-bsa-olive;
+        }
     }
 }

--- a/src/components/Layout/Footer/Footer.tsx
+++ b/src/components/Layout/Footer/Footer.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import Navigation from '../Navigation';
-import './Footer.scss';
+import styles from './Footer.module.scss';
 import pkg from '../../../../package.json';
 
 const Footer: React.FC = () => {
     const unitAddress = `${pkg.unit.address.street} - ${pkg.unit.address.city}, ${pkg.unit.address.state} ${pkg.unit.address.postalCode}`;
     return (
-        <footer className="scout-footer">
-            <div className="scout-footer-top">
+        <footer className={styles.container}>
+            <div className={styles.top}>
                 <p>
                     {unitAddress}
                     <br />
@@ -15,7 +15,7 @@ const Footer: React.FC = () => {
                 </p>
                 <Navigation />
             </div>
-            <div className="scout-footer-bottom">{pkg.unit.council.name}</div>
+            <div className={styles.bottom}>{pkg.unit.council.name}</div>
         </footer>
     );
 };

--- a/src/components/Layout/Header/Header.module.scss
+++ b/src/components/Layout/Header/Header.module.scss
@@ -1,6 +1,6 @@
 @import '../../../styles/variables';
 
-.scout-header {
+.container {
     background: $official-corporate-blue;
     border-bottom: 0.25rem solid $official-corporate-red;
     color: #fff;
@@ -33,7 +33,7 @@
         left: calc((4.0625rem / 2) - (3.125rem / 2) + 1rem);
     }
 
-    .scout-title {
+    .title {
         margin-left: calc(1rem + 4.0625rem + 0.65rem);
 
         h1 {
@@ -81,48 +81,36 @@
                 &:focus {
                     color: #fff;
                 }
-
-                &.active {
-                    background-color: $official-corporate-red;
-                    color: #fff;
-                }
             }
         }
+    }
+
+    :global .active {
+        background-color: $official-corporate-red;
+        color: #fff;
     }
 }
 
 html[data-theme='cub'] {
-    .scout-header {
+    .container {
         background-color: $official-cs-blue;
         border-bottom-color: $official-cs-gold;
 
-        ul {
-            li {
-                a {
-                    &.active {
-                        background-color: $official-cs-gold;
-                        color: $official-cs-blue;
-                    }
-                }
-            }
+        :global .active {
+            background-color: $official-cs-gold;
+            color: $official-cs-blue;
         }
     }
 }
 
 html[data-theme='bsa'] {
-    .scout-header {
+    .container {
         background-color: $official-bsa-olive;
         border-bottom-color: $official-bsa-tan;
 
-        ul {
-            li {
-                a {
-                    &.active {
-                        background-color: $official-bsa-tan;
-                        color: $official-bsa-olive;
-                    }
-                }
-            }
+        :global .active {
+            background-color: $official-bsa-tan;
+            color: $official-bsa-olive;
         }
     }
 }

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Navigation from '../Navigation';
 import { ReactComponent as Flag } from './Flag.svg';
-import './Header.scss';
+import styles from './Header.module.scss';
 import pkg from '../../../../package.json';
 import Logo from '../../Logo/Logo';
 
@@ -10,10 +10,10 @@ const Header: React.FC = () => {
     const unitLocation = `${pkg.unit.address.city}, ${pkg.unit.address.state}`;
 
     return (
-        <header className="scout-header">
+        <header className={styles.container}>
             <Flag />
             <Logo />
-            <div className="scout-title">
+            <div className={styles.title}>
                 <h1>{unitName}</h1>
                 <h2>{unitLocation}</h2>
             </div>

--- a/src/components/Logo/Logo.module.scss
+++ b/src/components/Logo/Logo.module.scss
@@ -1,4 +1,4 @@
-.scout-logo {
+.logo {
     width: 3.125rem;
     height: 3.125rem;
 }

--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import './Logo.scss';
+import styles from './Logo.module.scss';
 import { useScoutContext } from '../../contexts/ScoutContext';
 
 export interface LogoProps {
@@ -18,7 +18,7 @@ const Logo: React.FC<LogoProps> = props => {
         logoPath = './logo-bsa.svg';
     }
 
-    return <img src={logoPath} alt="Logo" className="scout-logo" />;
+    return <img src={logoPath} alt="Logo" className={styles.logo} />;
 };
 
 export default Logo;

--- a/src/contexts/ScoutContext.tsx
+++ b/src/contexts/ScoutContext.tsx
@@ -25,11 +25,10 @@ const ScoutProvider: React.FC = ({ children }) => {
         dataTheme = 'bsa';
     }
 
-    React.useEffect(() => {
-        if (dataTheme !== '') {
-            document.documentElement.setAttribute('data-theme', dataTheme);
-        }
-    }, []);
+    if (dataTheme !== '') {
+        document.documentElement.setAttribute('data-theme', dataTheme);
+    }
+
     return <ScoutContext.Provider value={value}>{children}</ScoutContext.Provider>;
 };
 


### PR DESCRIPTION
The following code removes direct SCSS in favor of using (S)CSS modules. This should enable component-specific styles and prevent collisions.